### PR TITLE
Add Plus options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is fork of the **Spec** reporter plugin for [TestCafe](http://devexpress.gi
 
 - Filter warnings by specifying filter option in testcafe's config file `.testface.js.`:
 - Log progress after each fixture. Disabled by default.
-- Add human-readable duration (with colors by duration!) to every test. Enabled by default.
+- Add human-readable duration (with colors by duration!) to every test. Disabled by default.
 
 ```js
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # testcafe-reporter-spec-plus
 
-This is fork of the **Spec** reporter plugin for [TestCafe](http://devexpress.github.io/testcafe). You can filter warnings by specifying filter option in testcafe's config file `.testface.js.`:
+This is fork of the **Spec** reporter plugin for [TestCafe](http://devexpress.github.io/testcafe). You can:
+
+- Filter warnings by specifying filter option in testcafe's config file `.testface.js.`:
+- Log progress after each fixture. Disabled by default.
 
 ```js
 module.exports = {
@@ -12,6 +15,7 @@ module.exports = {
                 "TestCafe cannot interact with the",  // Substring
                 /Was unable to take a screenshot due/ // Regex also could be used
             ],
+            showProgress: true // Log progress after each fixture
         },
     ]
 }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is fork of the **Spec** reporter plugin for [TestCafe](http://devexpress.gi
 
 - Filter warnings by specifying filter option in testcafe's config file `.testface.js.`:
 - Log progress after each fixture. Disabled by default.
+- Add human-readable duration (with colors by duration!) to every test. Enabled by default.
 
 ```js
 module.exports = {
@@ -15,7 +16,8 @@ module.exports = {
                 "TestCafe cannot interact with the",  // Substring
                 /Was unable to take a screenshot due/ // Regex also could be used
             ],
-            showProgress: true // Log progress after each fixture
+            showProgress: true  // Log progress after each fixture
+            showDuration: false // Switch off duration logging
         },
     ]
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
-# testcafe-reporter-spec
-[![Build Status](https://travis-ci.org/DevExpress/testcafe-reporter-spec.svg)](https://travis-ci.org/DevExpress/testcafe-reporter-spec)
+# testcafe-reporter-spec-plus
 
-This is the **Spec** reporter plugin for [TestCafe](http://devexpress.github.io/testcafe).
+This is fork of the **Spec** reporter plugin for [TestCafe](http://devexpress.github.io/testcafe). You can filter warnings by specifying filter option in testcafe's config file `.testface.js.`:
+
+```js
+module.exports = {
+    ...,
+    reporter: [
+        {
+            name: "spec-plus",
+            filter: [
+                "TestCafe cannot interact with the",  // Substring
+                /Was unable to take a screenshot due/ // Regex also could be used
+            ],
+        },
+    ]
+}
+```
 
 <p align="center">
     <img src="https://raw.github.com/DevExpress/testcafe-reporter-spec/master/media/preview.png" alt="preview" />
@@ -13,16 +27,16 @@ This reporter is shipped with TestCafe by default. In most cases, you won't need
 
 However, if you need to install this reporter, you can use the following command.
 
-```
-npm install testcafe-reporter-spec
+```sh
+npm install testcafe-reporter-spec-plus
 ```
 
 ## Usage
 
 When you run tests from the command line, specify the reporter name by using the `--reporter` option:
 
-```
-testcafe chrome 'path/to/test/file.js' --reporter spec
+```sh
+testcafe chrome 'path/to/test/file.js' --reporter spec-plus
 ```
 
 
@@ -33,9 +47,10 @@ testCafe
     .createRunner()
     .src('path/to/test/file.js')
     .browsers('chrome')
-    .reporter('spec') // <-
+    .reporter('spec-plus') // <-
     .run();
 ```
 
 ## Author
-Developer Express Inc. (https://devexpress.com)
+
+Developer Express Inc. (https://devexpress.com) and [George Kiselev](https://github.com/gooddaytoday)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "testcafe-reporter-spec",
+  "name": "testcafe-reporter-spec-plus",
   "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "testcafe-reporter-spec",
+      "name": "testcafe-reporter-spec-plus",
       "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testcafe-reporter-spec-plus",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "testcafe-reporter-spec-plus",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.21.3",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
-  "name": "testcafe-reporter-spec",
+  "name": "testcafe-reporter-spec-plus",
   "version": "2.2.0",
-  "description": "Spec TestCafe reporter plugin.",
-  "repository": "https://github.com/DevExpress/testcafe-reporter-spec",
+  "description": "Spec TestCafe reporter plugin with warnings filter and other bonuses.",
+  "repository": "https://github.com/gooddaytoday/testcafe-reporter-spec",
   "author": {
-    "name": "Developer Express Inc. ",
-    "url": "https://devexpress.com"
+    "name": "George Kiselev"
   },
   "main": "lib/index",
   "files": [
@@ -21,7 +20,8 @@
     "testcafe",
     "reporter",
     "plugin",
-    "spec"
+    "spec",
+    "filter"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-reporter-spec-plus",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Spec TestCafe reporter plugin with warnings filter and other bonuses.",
   "repository": "https://github.com/gooddaytoday/testcafe-reporter-spec",
   "author": {

--- a/src/index.js
+++ b/src/index.js
@@ -142,9 +142,9 @@ export default function () {
 
             if (durationMs < 60000)
                 return ` (${humanTime})`;
-            else if (durationMs < 120000)
+            else if (durationMs < 180000)
                 return ` (${this.chalk.yellow(humanTime)})`;
-            else if (durationMs < 500000)
+            else if (durationMs < 600000)
                 return ` (${this.chalk.hex('#FFA500')(humanTime)})`;
             else if (durationMs < 1000000)
                 return ` (${this.chalk.red(humanTime)})`;

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ export default function () {
     const reporterName = 'spec-plus';
 
     const configPath = path.resolve(process.cwd(), '.testcaferc.js');
+    let showProgress = false;
     let filter = [];
 
     if (fs.existsSync(configPath)) {
@@ -17,6 +18,8 @@ export default function () {
                 const filterList = reporter['filter'];
 
                 if (filterList) filter = filterList;
+                if (reporter['showProgress']) showProgress = true;
+                break;
             }
         }
     }
@@ -30,6 +33,7 @@ export default function () {
         startTime:      null,
         afterErrorList: false,
         testCount:      0,
+        testsFinished:  0,
         skipped:        0,
 
         reportTaskStart (startTime, userAgents, testCount) {
@@ -51,6 +55,8 @@ export default function () {
         },
 
         reportFixtureStart (name, filePath, meta) {
+            this._renderProgress();
+
             this.setIndent(1)
                 .useWordWrap(true);
 
@@ -80,6 +86,7 @@ export default function () {
         },
 
         reportTestDone (name, testRunInfo, meta) {
+            if (!testRunInfo.skipped) this.testsFinished++;
             const hasErr  = !!testRunInfo.errs.length;
             let symbol    = null;
             let nameStyle = null;
@@ -220,6 +227,17 @@ export default function () {
 
             if (warnings.length)
                 this._renderWarnings(warnings, writeData);
+        },
+
+        _renderProgress () {
+            if (showProgress && this.testsFinished > 0) {
+                this.newline()
+                    .setIndent(1)
+                    .write(`Completed tests: ${this.testsFinished}/${this.testCount}`)
+                    .newline();
+                if (this.afterErrorList)
+                    this.newline();
+            }
         },
     };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export default function () {
 
     const configPath = path.resolve(process.cwd(), '.testcaferc.js');
     let showProgress = false;
-    let showDuration = true;
+    let showDuration = false;
     let filter = [];
 
     if (fs.existsSync(configPath)) {
@@ -20,7 +20,7 @@ export default function () {
 
                 if (filterList) filter = filterList;
                 if (reporter['showProgress']) showProgress = true;
-                if (reporter['showDuration'] === false) showDuration = false;
+                if (reporter['showDuration']) showDuration = true;
                 break;
             }
         }


### PR DESCRIPTION
Added some usefull options to spec reporter:

- Filter warnings by specifying filter option in testcafe's config file `.testface.js.`:
- Log progress after each fixture. Disabled by default.
- Add human-readable duration (with colors by duration!) to every test. Enabled by default.

All options can be used only in `.testface.js.`:

```js
module.exports = {
    ...,
    reporter: [
        {
            name: "spec-plus",
            filter: [
                "TestCafe cannot interact with the",  // Substring
                /Was unable to take a screenshot due/ // Regex also could be used
            ],
            showProgress: true  // Log progress after each fixture
            showDuration: false // Switch off duration logging
        },
    ]
}
```