### PR TITLE
Add support for .testcaferc.cjs. Fixes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is fork of the **Spec** reporter plugin for [TestCafe](http://devexpress.github.io/testcafe). You can:
 
-- Filter warnings by specifying filter option in testcafe's config file `.testface.js.`:
+- Filter warnings by specifying filter option in testcafe's config files: `.testcaferc.cjs` and `.testcaferc.cjs`:
 - Log progress after each fixture. Disabled by default.
 - Add human-readable duration (with colors by duration!) to every test. Disabled by default.
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,11 @@ const path = require('path');
 export default function () {
     const reporterName = 'spec-plus';
 
-    const configPath = path.resolve(process.cwd(), '.testcaferc.js');
+    const configPath = ['.testcaferc.js', '.testcaferc.cjs'].reduce(
+        (acc, file) => acc || path.resolve(process.cwd(), file),
+        null
+    );
+
     let showProgress = false;
     let showDuration = false;
     let filter = [];
@@ -26,7 +30,7 @@ export default function () {
         }
     }
     else
-        console.log('No .testcaferc.js found');
+        console.log('No .testcaferc.js or .testcaferc.cjs found');
 
     const hasFilter = filter.length > 0;
 

--- a/test/data/configs/cjs/.testcaferc.js
+++ b/test/data/configs/cjs/.testcaferc.js
@@ -1,0 +1,3 @@
+module.exports = {
+    reporter: []
+};

--- a/test/data/configs/js/.testcaferc.js
+++ b/test/data/configs/js/.testcaferc.js
@@ -1,0 +1,3 @@
+module.exports = {
+    reporter: []
+};

--- a/test/test.js
+++ b/test/test.js
@@ -24,3 +24,39 @@ it('Should produce report without colors', function () {
 
     assert.strictEqual(report, expected);
 });
+
+describe('Resolving the config', () => {
+    const cwd = process.cwd();
+    const log = console.log;
+    /** @type {any[] | undefined} lastLog */
+    let lastLog;
+
+    beforeEach(() => {
+        console.log = (...args) => {
+            lastLog = args;
+        };
+    });
+
+    afterEach(() => {
+        console.log = log;
+        process.chdir(cwd);
+    });
+
+    it('Should find .testcaferc.js', function () {
+        process.chdir('test/data/configs/js');
+        require('../lib/index')();
+        assert.equal(lastLog?.[0], void 0);
+    });
+
+    it('Should find .testcaferc.cjs', function () {
+        process.chdir('test/data/configs/cjs');
+        require('../lib/index')();
+        assert.equal(lastLog?.[0], void 0);
+    });
+
+    it('Should abort if no config was found', function () {
+        process.chdir('test/data/configs/mjs');
+        require('../lib/index')();
+        assert.equal(lastLog?.[0], 'No .testcaferc.js or .testcaferc.cjs found');
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration file names in the documentation for the **Spec** reporter plugin to reflect the new `.testcaferc.cjs` format.

- **New Features**
  - Enhanced functionality to check for both `.testcaferc.js` and `.testcaferc.cjs` configuration files.

- **Tests**
  - Added new test cases to verify the correct resolution of configuration files in different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->