### PR TITLE
Fix config lookup.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,17 +4,16 @@ const path = require('path');
 
 export default function () {
     const reporterName = 'spec-plus';
+    const configPaths = ['.testcaferc.js', '.testcaferc.cjs'];
 
-    const configPath = ['.testcaferc.js', '.testcaferc.cjs'].reduce(
-        (acc, file) => acc || path.resolve(process.cwd(), file),
-        null
-    );
+    /** @type {string | undefined} */
+    const configPath = configPaths.map(file => path.resolve(process.cwd(), file)).find(file => fs.existsSync(file));
 
     let showProgress = false;
     let showDuration = false;
     let filter = [];
 
-    if (fs.existsSync(configPath)) {
+    if (configPath) {
         const config = require(configPath);
         const reporters = config['reporter'];
 

--- a/test/data/configs/cjs/.testcaferc.cjs
+++ b/test/data/configs/cjs/.testcaferc.cjs
@@ -1,3 +1,5 @@
+console.log('CJS');
+
 module.exports = {
     reporter: []
 };

--- a/test/data/configs/js/.testcaferc.js
+++ b/test/data/configs/js/.testcaferc.js
@@ -1,3 +1,5 @@
+console.log('JS');
+
 module.exports = {
     reporter: []
 };

--- a/test/test.js
+++ b/test/test.js
@@ -28,35 +28,36 @@ it('Should produce report without colors', function () {
 describe('Resolving the config', () => {
     const cwd = process.cwd();
     const log = console.log;
-    /** @type {any[] | undefined} lastLog */
-    let lastLog;
+    /** @type {any[][]} */
+    const logs = [];
 
     beforeEach(() => {
         console.log = (...args) => {
-            lastLog = args;
+            logs.push(args);
         };
     });
 
     afterEach(() => {
         console.log = log;
+        logs.splice(0, logs.length);
         process.chdir(cwd);
     });
 
     it('Should find .testcaferc.js', function () {
         process.chdir('test/data/configs/js');
         require('../lib/index')();
-        assert.equal(lastLog?.[0], void 0);
+        assert.deepStrictEqual(logs, [['JS']]);
     });
 
     it('Should find .testcaferc.cjs', function () {
         process.chdir('test/data/configs/cjs');
         require('../lib/index')();
-        assert.equal(lastLog?.[0], void 0);
+        assert.deepStrictEqual(logs, [['CJS']]);
     });
 
     it('Should abort if no config was found', function () {
         process.chdir('test/data/configs/mjs');
         require('../lib/index')();
-        assert.equal(lastLog?.[0], 'No .testcaferc.js or .testcaferc.cjs found');
+        assert.deepStrictEqual(logs, [['No .testcaferc.js or .testcaferc.cjs found']]);
     });
 });


### PR DESCRIPTION
The config path lookup I implemented in #3 had a bug where it did not actually look up a `.cjs` config. Tests didn't catch this because I saved both test config with ".js" extension 🤦‍♂️

In this PR, I've updated the tests to catch the error and for the config resolver to properly check if the file exists.

Sorry for the trouble.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced logging statements to configuration files, enhancing debugging capabilities.
  
- **Bug Fixes**
  - Improved the method for determining valid configuration paths, enhancing efficiency and readability.

- **Tests**
  - Updated the logging mechanism in the test suite to track multiple log entries, improving test accuracy and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->